### PR TITLE
Allowing to run with Latest version of IntelliJ IDEA

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ pluginUntilBuild = 252.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2025.2
+platformVersion = 2024.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION
This has been tested to work with my latest PyCharm and IntelliJ IDEA 2025.2.2 IDEs. All of the features described in the README are functional.