### PR TITLE
build: move Tencent Maven mirror after JitPack and Maven Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,13 +21,13 @@ kotlin {
 
 // Configure project's dependencies
 repositories {
-   maven {
-       url = uri("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/")
-   }
     maven {
         url = uri("https://jitpack.io")
     }
     mavenCentral()
+    maven {
+        url = uri("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/")
+    }
 
     // IntelliJ Platform Gradle Plugin Repositories Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-repositories-extension.html
     intellijPlatform {


### PR DESCRIPTION
## Summary

- Reorder Maven repositories in `build.gradle.kts` so JitPack and Maven Central are tried before the Tencent mirror.

## Why

The CI build for #141 fails while resolving `org.codeberg.gitnex:tea4j-autodeploy:439c7c4c1d`:

```
Could not find tea4j-autodeploy-439c7c4c1d.jar (org.codeberg.gitnex:tea4j-autodeploy:439c7c4c1d).
Searched in the following locations:
    https://mirrors.cloud.tencent.com/nexus/repository/maven-public/org/codeberg/gitnex/tea4j-autodeploy/439c7c4c1d/tea4j-autodeploy-439c7c4c1d.jar
```

The Tencent mirror returns POM metadata for that coordinate but not the JAR (the artifact is produced on-demand by JitPack from the Codeberg repo). Once Gradle resolves a module's metadata from a repository, it does not fall back to other repositories for the JAR — so listing the Tencent mirror first short-circuits resolution and breaks the build.

Moving the mirror after `jitpack.io` and `mavenCentral()` keeps it available for contributors who benefit from it while letting standard repositories serve dependencies they actually host.

Fixes #141

## Test plan

- [ ] CI build passes on this branch